### PR TITLE
Fix `.numberic` typo

### DIFF
--- a/app/assets/stylesheets/active_material/components/forms.scss
+++ b/app/assets/stylesheets/active_material/components/forms.scss
@@ -25,7 +25,7 @@ fieldset.inputs {
 
   &.string input,
   &.stringish input,
-  &.numberic input {
+  &.numeric input {
     @include am-textfield-input;
   }
 


### PR DESCRIPTION
Maybe I'm missing something because this seems so obvious on use... but the styling of numeric fields isn't working with `.numberic`.