### PR TITLE
Style country selects

### DIFF
--- a/app/assets/stylesheets/active_material/components/select.scss
+++ b/app/assets/stylesheets/active_material/components/select.scss
@@ -2,6 +2,7 @@
  * Basic Selects
  */
 
+.country,
 .select,
 .polymorphic_select {
 


### PR DESCRIPTION
[`country_select`](https://github.com/stefanpenner/country_select) uses a `.country` selector. Since `country_select` is recommended by [`formtastic`](https://github.com/justinfrench/formtastic/blob/b104bb1fe5228ea37f668917b13d0888f8bd033a/lib/formtastic/inputs/country_input.rb), I thought it might make sense to support this in this gem.