### PR TITLE
Don't make transparent li-s interactive

### DIFF
--- a/app/assets/stylesheets/active_material/components/utility_nav.scss
+++ b/app/assets/stylesheets/active_material/components/utility_nav.scss
@@ -52,6 +52,7 @@
     text-align: right;
     clip: rect(0, 0, 0, 0);
     opacity: 0;
+    visibility: hidden;
     transition: 0.28s all;
     position: relative;
 
@@ -69,6 +70,7 @@
     > li {
       clip: initial;
       opacity: 1;
+      visibility: visible;
     }
   }
 }


### PR DESCRIPTION
This is a fix that prevents `ul > li` from being interactive on `:hover`. I changed the styles in my app slightly and had the dropdown appear when I would hover _below_ the `ul` (on `opacity: 0` `li` element). This was preventing me from clicking on "New record" link below.