### PR TITLE
Make tabs background and border color configurable

### DIFF
--- a/app/assets/stylesheets/active_material/components/tabs.scss
+++ b/app/assets/stylesheets/active_material/components/tabs.scss
@@ -7,11 +7,11 @@
   @include am-tabs;
   @include am-tabs-list;
 
-  > li {
+  > li.ui-tabs-tab {
     @include am-tabs-list-item;
   }
 
-  > li > a {
+  > li.ui-tabs-tab > a {
     @include am-tabs-btn;
   }
 

--- a/app/assets/stylesheets/active_material/prototypes/tabs.scss
+++ b/app/assets/stylesheets/active_material/prototypes/tabs.scss
@@ -8,6 +8,9 @@ $am-tabs-background: am-color(primary) !default;
 $am-tabs-border-width: 3px !default;
 $am-tabs-color: rgba(#fff, 0.6) !default;
 $am-tabs-color-focus: #fff !default;
+$am-tabs-btn-background: inherit !default;
+$am-tabs-btn-background-focus: inherit !default;
+$am-tabs-btn-border-color: inherit !default;
 $am-tabs-font: $am-font-weight-regular 14px/16px $am-font-sans !default;
 
 @keyframes am-tabs-error-throb {
@@ -37,10 +40,12 @@ $am-tabs-font: $am-font-weight-regular 14px/16px $am-font-sans !default;
 
 @mixin am-tabs-list-item {
   display: inline-block;
+  border-color: $am-tabs-btn-border-color;
 }
 
 @mixin am-tabs-btn {
-  color: inherit;
+  background: $am-tabs-btn-background;
+  color: $am-tabs-color;
   cursor: pointer;
   display: block;
   font: $am-tabs-font;
@@ -83,6 +88,7 @@ $am-tabs-font: $am-font-weight-regular 14px/16px $am-font-sans !default;
 }
 
 @mixin am-tabs-btn-active {
+  background: $am-tabs-btn-background-focus;
   color: $am-tabs-color-focus;
 
   &:after {

--- a/app/assets/stylesheets/active_material/prototypes/tabs.scss
+++ b/app/assets/stylesheets/active_material/prototypes/tabs.scss
@@ -72,7 +72,7 @@ $am-tabs-font: $am-font-weight-regular 14px/16px $am-font-sans !default;
 
   &:focus,
   &:hover {
-    background: transparent;
+    background: $am-tabs-btn-background-focus;
     outline: none;
     text-decoration: none;
 
@@ -95,6 +95,11 @@ $am-tabs-font: $am-font-weight-regular 14px/16px $am-font-sans !default;
     @include am-fill(accent);
     box-shadow: 0 -1px 1px rgba(#000, 0.1), inset 0 1px 1px rgba(#fff, 0.50);
     transform: none;
+  }
+
+  &:focus,
+  &:hover {
+    background: $am-tabs-btn-background-focus;
   }
 }
 


### PR DESCRIPTION
It would be nice to configure background and border colors for Tabs in case one doen't like the color that is defined by jquery-ui.
I added some variables with a default value `inherit` so that this change would only apply when those variables are set.

|Before|After*|
|-------|------|
|![Tabs_before](https://user-images.githubusercontent.com/6471346/55230995-b8d6e400-5221-11e9-8bf5-9f5d4de0cbd6.png)|![Tabs_after](https://user-images.githubusercontent.com/6471346/55231005-bd030180-5221-11e9-8a43-35e260b7bd3d.png)|

\* For the after screenshot I set the following values:

```scss
$am-tabs-btn-background-focus: #FFFFFF;
$am-tabs-btn-background: #FFFFFF;
$am-tabs-btn-border-color: #B3BCC1;
```