### PR TITLE
[Gemspec] Adds sass-rails as a dependency

### DIFF
--- a/active_material.gemspec
+++ b/active_material.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "sass-rails"
 end


### PR DESCRIPTION
I ran into the `sass-rails` dependency issue myself when using `active-material` - I saw a note in this issue: https://github.com/vigetlabs/active_material/issues/61 about adding it as a an explicit dependency so I thought I'd throw a PR up for that.

I figured, if this is too overkill or not quite how you guys want to handle it - would a simple update to the README satisfy this as well?

Excellent job on this gem, it's an incredible way to enhance active admin! Let me know how/if I can help!