### PR TITLE
Add styling for comments

### DIFF
--- a/app/assets/stylesheets/active_material/components/comments.scss
+++ b/app/assets/stylesheets/active_material/components/comments.scss
@@ -1,0 +1,28 @@
+/**
+ * Comments
+ * Active Admin comments
+ */
+
+div.active_admin_comment {
+  margin: 0 16px;
+
+  & + & {
+    border-top: 1px solid am-color(divider);
+    padding-top: am-unit(2);
+  }
+}
+
+.active_admin_comment_meta {
+  @include am-color(secondary-text);
+  @include am-type-caption;
+}
+
+.comments {
+  .pagination_information {
+    margin: 16px;
+  }
+
+  .empty {
+    margin: 16px;
+  }
+}


### PR DESCRIPTION
Fixes #55 

I just added very minimal styling. Hope that's fine.

**Before:**
<img width="487" alt="comments_before" src="https://user-images.githubusercontent.com/6471346/67667177-8d5dd880-f96d-11e9-95ea-8909c8032dce.png">


**After:**
![comments_after](https://user-images.githubusercontent.com/6471346/67667189-9189f600-f96d-11e9-9df4-2124445de10d.png)
